### PR TITLE
Поправил баг с дублированием коментариев + тест

### DIFF
--- a/src/Tests/CommentsTests.cs
+++ b/src/Tests/CommentsTests.cs
@@ -85,6 +85,25 @@ namespace ConfigSettingsTests
       SaveInFileAndCheck(linesToAdd);
     }
 
+    [Test]
+    public void WhenSaveImportWithCommentsShouldNotDuplicate()
+    {
+      var linesToAdd = new List<string>() {
+        @"<import from=""_imported_config.xml"" />",
+        "<!--Import comment 1-->",
+        "<!--Import comment 2-->",
+        @"<var name=""HELP_URI"" value=""https://help.npo-comp.ru/DirectumRX/Web"" />",
+        "<!--Import comment 3-->",
+        "<!--Import comment 4-->", };
+      var tempFile = this.CreateSettings(string.Join("\n", linesToAdd));
+      var parser = new ConfigSettingsParser(tempFile);
+      parser.Save();
+
+      var rawFileLines = File.ReadAllLines(tempFile);
+      var fileLines = rawFileLines.Take(rawFileLines.Length-1).Skip(2).Select(l => l.Trim()).ToArray();
+      linesToAdd.SequenceEqual(fileLines).Should().BeTrue();
+    }
+
     private bool IsFileContainLines(string path, List<string> lines)
     {
       var fileLines = File.ReadAllLines(path).Select(l => l.Trim());


### PR DESCRIPTION
Поправил ошибку с дублированием комментариев при сохранении конфига. Если в файле есть многострочный комментарий, а после него идет что-то значимое (переменная, блок, импорт, метапеременная), то часть комментариев учитывалась и в коллекции комментариев всего файла и в коллекции комментариев этого значимого элемента.
Пример:
 ```
 <!-- Комментарий 1. -->
 <!-- Комментарий 2. -->
 <var name="VAR1" value="1" />
```

При сохранении это превратится:
```
  <!-- Комментарий 1. -->
  <!-- Комментарий 2. -->
  <var name="VAR1" value="1" />
  <!-- Комментарий 1. -->
```

Тесты проходили, потому что в них не отслеживались дубли, а только вхождения изначальных строк. Добавил тест на этот кейс.